### PR TITLE
Add element ID

### DIFF
--- a/lib/Neo4j/Types/Node.pod
+++ b/lib/Neo4j/Types/Node.pod
@@ -32,6 +32,26 @@ how that particular module handles this aspect.
 
 L<Neo4j::Types::Node> implements the following methods.
 
+=head2 element_id
+
+ $string = $node->element_id;
+
+Return an ID string for this node that is unique within
+a particular context, for example the current transaction.
+
+The element ID string was introduced with Neo4j 5. When it is
+unavailable, for example because this module is used with Neo4j
+server S<version 4> or earlier, the behaviour of this method is
+undefined. However, as of early 2023, the common approach is to
+simply yield the S<numeric ID> instead; see L<C<id()>|/"id">.
+Note that a S<numeric ID> cannot successfully be used with
+C<elementId()> in Cypher expressions.
+
+Neo4j node IDs are not designed to be persistent.
+As such, if you want a public identity to use for your
+nodes, attaching an explicit "id" property is a
+better choice than using the Neo4j node ID.
+
 =head2 get
 
  $value = $node->get('property_key');
@@ -41,18 +61,23 @@ key. If no such key exists, return C<undef>.
 
 =head2 id
 
- $id = $node->id;
+ $number = $node->id;
 
-Return an ID for this node that is unique within
-a particular context, for example the current
-L<driver session|Neo4j::Driver::Session> or
-L<Bolt connection|Neo4j::Bolt::Cxn>.
+Return a legacy numeric ID for this node that is
+unique within a particular context, for example the
+current transaction.
+
+Neo4j 5 has B<deprecated> numeric IDs. They may become
+unavailable in future. The behaviour of this method for
+this situation is undefined; implementations may yield
+an undefined value with or without warning or C<die>.
 
 Neo4j node IDs are not designed to be persistent.
-After a node is deleted, its ID may be reused by
-another node.
+As such, if you want a public identity to use for your
+nodes, attaching an explicit 'id' property is a
+better choice than using the Neo4j node ID.
 
-IDs are always integer numbers.
+Legacy IDs are always integer numbers.
 A node with the ID C<0> may exist.
 Nodes and relationships do not share the same ID space.
 

--- a/lib/Neo4j/Types/Relationship.pod
+++ b/lib/Neo4j/Types/Relationship.pod
@@ -35,6 +35,26 @@ how that particular module handles this aspect.
 
 L<Neo4j::Types::Relationship> implements the following methods.
 
+=head2 element_id
+
+ $string = $node->element_id;
+
+Return an ID string for this relationship that is unique within
+a particular context, for example the current transaction.
+
+The element ID string was introduced with Neo4j 5. When it is
+unavailable, for example because this module is used with Neo4j
+server S<version 4> or earlier, the behaviour of this method is
+undefined. However, as of early 2023, the common approach is to
+simply yield the S<numeric ID> instead; see L<C<id()>|/"id">.
+Note that a S<numeric ID> cannot successfully be used with
+C<elementId()> in Cypher expressions.
+
+Neo4j relationship IDs are not designed to be persistent.
+As such, if you want a public identity to use for your
+relationships, attaching an explicit "id" property is a
+better choice than using the Neo4j relationship ID.
+
 =head2 get
 
  $value = $relationship->get('property_key');
@@ -44,18 +64,23 @@ key. If no such key exists, return C<undef>.
 
 =head2 id
 
- $id = $relationship->id;
+ $number = $relationship->id;
 
-Return an ID for this relationship that is unique within
-a particular context, for example the current
-L<driver session|Neo4j::Driver::Session> or
-L<Bolt connection|Neo4j::Bolt::Cxn>.
+Return a legacy numeric ID for this relationship that is
+unique within a particular context, for example the
+current transaction.
+
+Neo4j 5 has B<deprecated> numeric IDs. They may become
+unavailable in future. The behaviour of this method for
+this situation is undefined; implementations may yield
+an undefined value with or without warning or C<die>.
 
 Neo4j relationship IDs are not designed to be persistent.
-After a relationship is deleted, its ID may be reused by
-another relationship.
+As such, if you want a public identity to use for your
+relationships, attaching an explicit "id" property is a
+better choice than using the Neo4j relationship ID.
 
-IDs are always integer numbers.
+Legacy IDs are always integer numbers.
 A relationship with the ID C<0> may exist.
 Nodes and relationships do not share the same ID space.
 
@@ -66,17 +91,33 @@ Nodes and relationships do not share the same ID space.
 
 Return all properties of this relationship as a hash reference.
 
+=head2 start_element_id
+
+ $string = $relationship->start_element_id;
+
+Return an element ID for the node where this relationship starts.
+See L<Neo4j::Types::Node/"element_id">.
+
 =head2 start_id
 
- $id = $relationship->start_id;
+ $number = $relationship->start_id;
 
-Return an ID for the node where this relationship starts.
+Return a numeric ID for the node where this relationship starts.
+See L<Neo4j::Types::Node/"id">.
+
+=head2 end_element_id
+
+ $string = $relationship->end_element_id;
+
+Return an element ID for the node where this relationship ends.
+See L<Neo4j::Types::Node/"element_id">.
 
 =head2 end_id
 
- $id = $relationship->end_id;
+ $number = $relationship->end_id;
 
-Return an ID for the node where this relationship ends.
+Return a numeric ID for the node where this relationship ends.
+See L<Neo4j::Types::Node/"id">.
 
 =head2 type
 


### PR DESCRIPTION
Initial attempt to cover the Neo4j 5 element ID (#2).

The initial proposal is to declare the behaviour of `element_id()` on Neo4j ≤ 4 to be “undefined”. This technically matches the official Neo4j documentation, which is silent on the matter, but all the official drivers actually treat it as an alias to `id()` when used with old server versions. Declaring it to be “undefined” offers maximum flexibility to driver authors here.

However, perhaps we should instead rather choose one specific behaviour in the interest of interoperability. In that case, our choice shouldn’t necessarily be the same as the official drivers’ choice. Yielding the legacy numeric ID on a call to `element_id()` seems pretty useless – nonsensical, even. You can’t use it with Cypher’s `elementId()` function. That’s actually a bit of a problem for us because the element ID may well be unavailable to Perl drivers even with Neo4j 5 because of network protocol issues (e. g. Jolt v1). The official first-party drivers don’t have that problem.

Therefore, perhaps `element_id()` should provide something like `undef` instead when that value is unavailable.

A similar question arises about the future behaviour of `id()`, once the legacy numeric ID becomes unavailable in Neo4j (maybe in version 6). The initial proposal doesn’t define this either, but perhaps it should try to do so.

Not yet included here is a deprecation warning for `id()`. Such a warning should be allowed with Neo4j 5+, but not with earlier versions, because it doesn’t make sense for users of old server versions to use anything other than `id()`.