### PR TITLE
Add element ID, with a requirement to warn if unavailable

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,6 @@
 Revision history for Neo4j::Types
 
-1.07  UNRELEASED
+1.08  UNRELEASED
 
  - Define scalar context for list methods to yield number of elements
  - Define properties() to behave the same in list context as in scalar context.
@@ -10,6 +10,7 @@ Revision history for Neo4j::Types
  - Add Neo4j::Types::Generic namespace for generic type implementations.
  - Move spatial point implementation into Neo4j::Types::Generic namespace.
  - Add DateTime and Duration temporal types.
+ - Define methods and behaviour for the Neo4j 5 element ID.
 
 1.00  2021-01-18
 

--- a/dist.ini
+++ b/dist.ini
@@ -6,7 +6,7 @@ license = Artistic_2_0
 copyright_holder = Arne Johannessen
 copyright_year   = 2021-2023
 
-version = 1.07
+version = 1.08
 release_status = unstable
 
 [@Author::AJNN]

--- a/lib/Neo4j/Types.pm
+++ b/lib/Neo4j/Types.pm
@@ -5,6 +5,8 @@ package Neo4j::Types;
 # ABSTRACT: Common Neo4j type system
 
 
+use warnings::register;
+
 use Neo4j::Types::Node;
 use Neo4j::Types::Path;
 use Neo4j::Types::Point;

--- a/lib/Neo4j/Types/ImplementorNotes.pod
+++ b/lib/Neo4j/Types/ImplementorNotes.pod
@@ -69,16 +69,28 @@ L<Neo4j::Types::Node> as a parent type.
  sub labels     ($self) {...}
  
  sub id         ($self) {...}
+ sub element_id ($self) {...}
 
 You are free in your choice of the internal data structure.
 While L<Neo4j::Types::Node> currently provides default
-implementations of all methods, these only exist because some
+implementations of most methods, these only exist because some
 versions of L<Neo4j::Bolt::Node> might expect them.
 They may be removed in future and should not be relied upon.
 
 It is recommended that the C<id()> method returns a number for
 which L<builtin/"created_as_number"> would be truthy (S<e. g.>
 C<0 + $id>). This can make roundtrips easier.
+
+When the element ID is unavailable, C<element_id()> must by
+default issue a warning and must otherwise behave like an alias
+for C<id()>. When the S<element ID> I<is> available, C<id()>
+may optionally issue a deprecation warning. The behaviour of
+C<id()> when the legacy ID is unavailable is undefined.
+
+For implementations geared only towards S<Neo4j 4> and older,
+C<element_id()> is currently an optional operation.
+While C<id()> is currently mandatory, it may similarly become
+an optional operation for newer Neo4j versions in future.
 
 The C<labels()> and C<properties()> methods must not return
 C<undef>. If there are no labels or properties, an empty list
@@ -115,10 +127,14 @@ L<Neo4j::Types::Relationship> as a parent type.
  sub id         ($self) {...}
  sub start_id   ($self) {...}
  sub end_id     ($self) {...}
+ 
+ sub element_id       ($self) {...}
+ sub start_element_id ($self) {...}
+ sub end_element_id   ($self) {...}
 
 You are free in your choice of the internal data structure.
 While L<Neo4j::Types::Relationship> currently provides default
-implementations of all methods, these only exist because some
+implementations of most methods, these only exist because some
 versions of L<Neo4j::Bolt::Relationship> might expect them.
 They may be removed in future and should not be relied upon.
 
@@ -126,6 +142,10 @@ It is recommended that the methods C<id()>, C<start_id()>,
 and C<end_id()> return a number for which
 L<builtin/"created_as_number"> would be truthy
 (S<e. g.> C<0 + $id>). This can make roundtrips easier.
+
+For C<element_id()>, C<id()> and related methods, the same
+considerations as above for C<element_id()> and C<id()>
+on L<nodes|/"Node"> apply.
 
 For the C<get()> and C<properties()> methods, the same
 considerations as above for C<get()> and C<properties()>

--- a/lib/Neo4j/Types/Node.pod
+++ b/lib/Neo4j/Types/Node.pod
@@ -5,8 +5,10 @@
 
 =head1 SYNOPSIS
 
- $node_id = $node->id;
  @labels  = $node->labels;
+ 
+ $node_id = $node->element_id;  # Neo4j 5 and newer
+ $node_id = $node->id;          # Neo4j 4 and older
  
  $property1  = $node->get('property1');
  $property2  = $node->get('property2');
@@ -28,9 +30,32 @@ Refer to the documentation of the Perl module you use to
 fetch nodes from the Neo4j database for information about
 how that particular module handles this aspect.
 
+Neo4j node IDs are not designed to be persistent.
+As such, if you want a public identity to use for your
+nodes, attaching an explicit "id" property is a
+better choice than using the Neo4j node ID or
+S<element ID>.
+
 =head1 METHODS
 
 L<Neo4j::Types::Node> implements the following methods.
+
+=head2 element_id
+
+ $string = $node->element_id;
+
+Return an ID string for this node that is unique within
+a particular context, for example the current transaction.
+
+The element ID string was introduced with Neo4j 5. When it is
+unavailable, for example because this module is used with Neo4j
+server S<version 4> or earlier, this method will issue a
+warning in the C<Neo4j::Types> category and return the legacy
+S<numeric ID> instead; see L<C<id()>|/"id">.
+
+=for comment
+Note that a S<numeric ID> cannot successfully be used
+with C<elementId()> in Cypher expressions.
 
 =head2 get
 
@@ -41,18 +66,17 @@ key. If no such key exists, return C<undef>.
 
 =head2 id
 
- $id = $node->id;
+ $number = $node->id;
 
-Return an ID for this node that is unique within
-a particular context, for example the current
-L<driver session|Neo4j::Driver::Session> or
-L<Bolt connection|Neo4j::Bolt::Cxn>.
+Return a legacy numeric ID for this node that is
+unique within a particular context, for example the
+current transaction.
 
-Neo4j node IDs are not designed to be persistent.
-After a node is deleted, its ID may be reused by
-another node.
+On Neo4j 5 and above, numeric IDs are B<deprecated.>
+They may become unavailable in future.
+Use L<C<element_id()>|/"element_id"> instead.
 
-IDs are always integer numbers.
+Legacy IDs are always integer numbers.
 A node with the ID C<0> may exist.
 Nodes and relationships do not share the same ID space.
 

--- a/lib/Neo4j/Types/Relationship.pod
+++ b/lib/Neo4j/Types/Relationship.pod
@@ -5,9 +5,15 @@
 
 =head1 SYNOPSIS
 
- $rel_id   = $relationship->id;
  $rel_type = $relationship->type;
  
+ # Neo4j 5 and newer
+ $rel_id        = $relationship->element_id;
+ $start_node_id = $relationship->start_element_id;
+ $end_node_id   = $relationship->end_element_id;
+ 
+ # Neo4j 4 and older
+ $rel_id        = $relationship->id;
  $start_node_id = $relationship->start_id;
  $end_node_id   = $relationship->end_id;
  
@@ -31,9 +37,32 @@ Refer to the documentation of the Perl module you use to
 fetch relationships from the Neo4j database for information about
 how that particular module handles this aspect.
 
+Neo4j relationship IDs are not designed to be persistent.
+As such, if you want a public identity to use for your
+relationships, attaching an explicit "id" property is a
+better choice than using the Neo4j relationship ID or
+S<element ID>.
+
 =head1 METHODS
 
 L<Neo4j::Types::Relationship> implements the following methods.
+
+=head2 element_id
+
+ $string = $relationship->element_id;
+
+Return an ID string for this relationship that is unique within
+a particular context, for example the current transaction.
+
+The element ID string was introduced with Neo4j 5. When it is
+unavailable, for example because this module is used with Neo4j
+server S<version 4> or earlier, this method will issue a
+warning in the C<Neo4j::Types> category and return the legacy
+S<numeric ID> instead; see L<C<id()>|/"id">.
+
+=for comment
+Note that a S<numeric ID> cannot successfully be used
+with C<elementId()> in Cypher expressions.
 
 =head2 get
 
@@ -44,18 +73,17 @@ key. If no such key exists, return C<undef>.
 
 =head2 id
 
- $id = $relationship->id;
+ $number = $relationship->id;
 
-Return an ID for this relationship that is unique within
-a particular context, for example the current
-L<driver session|Neo4j::Driver::Session> or
-L<Bolt connection|Neo4j::Bolt::Cxn>.
+Return a legacy numeric ID for this relationship that is
+unique within a particular context, for example the
+current transaction.
 
-Neo4j relationship IDs are not designed to be persistent.
-After a relationship is deleted, its ID may be reused by
-another relationship.
+On Neo4j 5 and above, numeric IDs are B<deprecated.>
+They may become unavailable in future.
+Use L<C<element_id()>|/"element_id"> instead.
 
-IDs are always integer numbers.
+Legacy IDs are always integer numbers.
 A relationship with the ID C<0> may exist.
 Nodes and relationships do not share the same ID space.
 
@@ -66,17 +94,33 @@ Nodes and relationships do not share the same ID space.
 
 Return all properties of this relationship as a hash reference.
 
+=head2 start_element_id
+
+ $string = $relationship->start_element_id;
+
+Return an element ID for the node where this relationship starts.
+See L<Neo4j::Types::Node/"element_id">.
+
 =head2 start_id
 
- $id = $relationship->start_id;
+ $number = $relationship->start_id;
 
-Return an ID for the node where this relationship starts.
+Return a numeric ID for the node where this relationship starts.
+See L<Neo4j::Types::Node/"id">.
+
+=head2 end_element_id
+
+ $string = $relationship->end_element_id;
+
+Return an element ID for the node where this relationship ends.
+See L<Neo4j::Types::Node/"element_id">.
 
 =head2 end_id
 
- $id = $relationship->end_id;
+ $number = $relationship->end_id;
 
-Return an ID for the node where this relationship ends.
+Return a numeric ID for the node where this relationship ends.
+See L<Neo4j::Types::Node/"id">.
 
 =head2 type
 


### PR DESCRIPTION
Another attempt to cover the Neo4j 5 element ID, after https://github.com/johannessen/neo4j-types/pull/3#issuecomment-1651538996.

This proposal requires implementations to return the numeric ID and issue a warning in the `Neo4j::Types` category when the element ID is missing (e.g. with a Neo4j 4 server).

The behaviour for a missing numeric ID is now explicitly undefined, because not just the “when”, but also the “how” of the way in which Neo4j servers will (presumably) eventually stop providing it is unknown. Deprecation warnings to adequately prepare users for this scenario are explicitly allowed for `id()` on Neo4j 5 and later.

Under this proposal, offering `element_id()` methods is optional for implementations that don’t (yet) target Neo4j 5. This is primarily to ease testing during a transition period.