### PR TITLE
Expand guidance for booleans

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,6 @@
 Revision history for Neo4j::Types
 
-1.11  UNRELEASED
+1.12  UNRELEASED
 
  - Define scalar context for list methods to yield number of elements
  - Define properties() to behave the same in list context as in scalar context.
@@ -14,6 +14,7 @@ Revision history for Neo4j::Types
  - Define methods and behaviour for the Neo4j 5 element ID.
  - Raise minimum required version of Perl to v5.10.1.
  - Add ByteArray type.
+ - Specify the boolean values to be used (core bools on v5.36+).
 
 1.00  2021-01-18
 

--- a/dist.ini
+++ b/dist.ini
@@ -6,7 +6,7 @@ license = Artistic_2_0
 copyright_holder = Arne Johannessen
 copyright_year   = 2021-2023
 
-version = 1.11
+version = 1.12
 release_status = unstable
 
 [@Author::AJNN]

--- a/lib/Neo4j/Types/ImplementorNotes.pod
+++ b/lib/Neo4j/Types/ImplementorNotes.pod
@@ -230,19 +230,56 @@ not treated as UTF-8 internally for efficiency reasons.
 
 =head2 Boolean
 
-Perl only gained useful native boolean values
-L<in version 5.35.4|perl5354delta/"Stable boolean tracking">.
-On earlier versions, various CPAN modules attempt to solve
-this problem, including L<boolean>, L<Types::Bool>, and
-L<Types::Serialiser>. Among them, L<JSON::PP::Boolean> has
-the advantage that it has long been in Perl CORE.
+When reading a boolean from Neo4j, a value representing
+C<true> must evaluate truthy in Perl and a Neo4j value
+representing C<false> must not. Values must be trackable
+as boolean by default to provide round-trip capability.
 
+The following two pairs of Perl values meet these
+requirements and should be used by default:
+
+=over
+
+=item On Perl version 5.36 and newer:
+
+L<C<builtin::true>|builtin/"true"> and
+L<C<builtin::false>|builtin/"false">
+
+=item On older Perl versions:
+
+C<L<JSON::PP>::true> and
+C<L<JSON::PP>::false>
+
+=back
+
+When running on v5.36 or newer, both of these boolean types
+should be accepted as query parameters for writing to Neo4j.
+
+Additional values may optionally be accepted, such as
+C<\1> and C<\0>, L<boolean>, or L<Types::Bool>.
+There is a variety of CPAN modules representing booleans
+because Perl only gained useful native boolean values
+L<in S<version v5.36>|perl5360delta/"Stable boolean tracking">.
+Modules like L<builtin::compat> might help
+with tracking native bools in earlier versions.
+
+=for comment
+(Internally, Perl has long had native boolean values,
+but it was difficult to track their boolean status,
+especially outside XS code. See L<perlapi/"boolSV">,
+L<makamaka/JSON-PP#49|https://github.com/makamaka/JSON-PP/issues/49>.)
+
+Optionally, your implementation may offer users a way
+to choose the boolean values. This document makes no
+recommendation as to the interface for such an option.
+
+=for comment
 Some of the Perl JSON modules are currently (2023) in the
-process of adding support for Perl native booleans. It may
-be useful to wait until those L<builtin> functions that
-provide access to Perl native booleans have left
-L<experimental status|perlexperiment/"The builtin namespace">
-and then follow whichever approach those other modules chose.
+process of adding support for core booleans. It may be
+useful to wait until those implementations are completed
+and then follow whichever approach they chose. See also:
+L<JSON::PP/"boolean_values">,
+L<rurban/Cpanel-JSON-XS#214|https://github.com/rurban/Cpanel-JSON-XS/issues/214>
 
 =head2 Null
 


### PR DESCRIPTION
The proposed text more or less follows Postel’s Law: Liberally accept several common boolean formats as parameters for sending to Neo4j, but output a format with specific criteria.

The primary open question seems to be how clients would choose the boolean values, and which values should be the default.

Most of the Perl JSON modules seem to be moving towards compatibility with ["boolean_values" in JSON::PP](https://metacpan.org/pod/JSON::PP#boolean_values) and core booleans as the default, but the details may still be evolving.

Perhaps addressing https://github.com/majensen/perlbolt/issues/42 should wait until those changes have been released, so that we can easily make Neo4j::Bolt and Neo4j::Driver behave the same way.