### PR TITLE
Move Point implementation into Generic namespace

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,12 +1,14 @@
 Revision history for Neo4j::Types
 
-1.05  UNRELEASED
+1.06  UNRELEASED
 
  - Define scalar context for list methods to yield number of elements
  - Define properties() to behave the same in list context as in scalar context.
  - Define result of reading a non-existent property to be undef.
  - Clarify that labels() and properties() must not return undef.
  - Recommend that users don't inherit type implementations from these roles.
+ - Add Neo4j::Types::Generic namespace for generic type implementations.
+ - Move spatial point implementation into Neo4j::Types::Generic namespace.
 
 1.00  2021-01-18
 

--- a/dist.ini
+++ b/dist.ini
@@ -6,7 +6,7 @@ license = Artistic_2_0
 copyright_holder = Arne Johannessen
 copyright_year   = 2021-2023
 
-version = 1.05
+version = 1.06
 release_status = unstable
 
 [@Author::AJNN]

--- a/lib/Neo4j/Types/Generic.pod
+++ b/lib/Neo4j/Types/Generic.pod
@@ -1,0 +1,86 @@
+# PODNAME: Neo4j::Types::Generic
+# ABSTRACT: Generic Neo4j type implementations
+
+=encoding UTF-8
+
+=head1 OVERVIEW
+
+The L<Neo4j::Types> distribution includes generic
+implementations of some Neo4j property types.
+This enables users to easily create values of these types
+locally, for example to pass these back to Neo4j in a query
+parameter.
+
+Neo4j drivers may provide similar packages, which might
+be better optimised for use with the respective driver.
+As long as each of them performs the appropriate role
+from L<Neo4j::Types>, they should all be interchangeable.
+
+=head1 Point
+
+Neo4j::Types::Generic::Point offers the following methods
+in addition to those defined in L<Neo4j::Types::Point>.
+
+=head2 height
+
+ $value = $point->height;
+
+Alias for L<C<Z()>|/"Z">.
+
+=head2 latitude
+
+ $value = $point->latitude;
+
+Alias for L<C<Y()>|/"Y">.
+
+=head2 longitude
+
+ $value = $point->longitude;
+
+Alias for L<C<X()>|/"X">.
+
+=head2 new
+
+ $point = Neo4j::Types::Generic::Point->new($neo4j_srid, @coordinates);
+
+Creates a new generic Point instance with the specified value.
+
+This method will fail if the SRID provided is not supported by Neo4j
+or if it requires a greater number of coordinates than provided.
+See L<Neo4j::Types::Point/"srid">.
+
+=head2 X
+
+ $value = $point->X;  # uppercase X
+
+Retrieve the point's first ordinate, also known as the abscissa.
+Commonly used for the horizontal axis in an Euclidean plane or for
+the geographical longitude.
+
+=head2 Y
+
+ $value = $point->Y;  # uppercase Y
+
+Retrieve the point's second ordinate. Commonly used for the vertical
+axis in an Euclidean plane or for the geographical latitude.
+
+=head2 Z
+
+ $value = $point->Z;  # uppercase Z
+
+Retrieve the point's third ordinate. Commonly used for height.
+
+For points in coordinate systems that have no more than two
+dimensions, this method returns C<undef>.
+
+=head1 SEE ALSO
+
+=over
+
+=item * L<Neo4j::Types>
+
+=item * L<Neo4j::Types::Point>
+
+=item * L<Neo4j::Types::ImplementorNotes>
+
+=back

--- a/lib/Neo4j/Types/Generic/Point.pm
+++ b/lib/Neo4j/Types/Generic/Point.pm
@@ -1,0 +1,42 @@
+use strict;
+use warnings;
+
+package Neo4j::Types::Generic::Point;
+# ABSTRACT: Generic representation of a Neo4j spatial point value
+
+
+use parent 'Neo4j::Types::Point';
+
+use Carp qw(croak);
+
+
+my %DIM = ( 4326 => 2, 4979 => 3, 7203 => 2, 9157 => 3 );
+
+sub new {
+	my ($class, $srid, @coordinates) = @_;
+	
+	croak "Points must have SRID" unless defined $srid;
+	my $dim = $DIM{$srid};
+	croak "Unsupported SRID $srid" unless defined $dim;
+	croak "Points with SRID $srid must have $dim dimensions" if @coordinates < $dim;
+	return bless [ $srid, @coordinates[0 .. $dim - 1] ], __PACKAGE__;
+}
+
+
+sub X { shift->[1] }
+sub Y { shift->[2] }
+sub Z { shift->[3] }
+
+sub longitude { shift->[1] }
+sub latitude  { shift->[2] }
+sub height    { shift->[3] }
+
+sub srid { shift->[0] }
+
+sub coordinates {
+	my @coordinates = @{$_[0]}[ 1 .. $#{$_[0]} ];
+	return @coordinates;
+}
+
+
+1;

--- a/lib/Neo4j/Types/ImplementorNotes.pod
+++ b/lib/Neo4j/Types/ImplementorNotes.pod
@@ -270,27 +270,17 @@ L<Neo4j::Types::Point> as a parent type.
  package Local::Point;
  use parent 'Neo4j::Types::Point';
  
- sub new         ($class, $neo4j_srid, @coordinates) {...}
  sub srid        ($self) {...}
  sub coordinates ($self) {...}
- 
- sub X           ($self) {...}  # uppercase X
- sub longitude   ($self) {...}
- 
- sub Y           ($self) {...}  # uppercase Y
- sub latitude    ($self) {...}
- 
- sub Z           ($self) {...}  # uppercase Z
- sub height      ($self) {...}
 
-You are free in the choice of your own module's internal
-data structure. If you instead choose to use the generic
-implementation provided by L<Neo4j::Types::Point> itself, you
-should treat it as entirely opaque and should not access the
-data structure in any other way than through the methods
-specified in L<Neo4j::Types::Point>.
+You are free in your choice of the internal data structure.
+L<Neo4j::Types::Point> used to provide default implementations
+of all methods, but these have been moved to
+L<Neo4j::Types::Generic::Point> with version 2.00.
+The C<new()> method still exists for backwards compatibility,
+but it may be removed in future and should not be relied upon.
 
-It is recommended that all methods return a number for which
+It is recommended that all methods return numbers for which
 L<builtin/"created_as_number"> would be truthy
 (S<e. g.> C<0 + $srid>). This can make roundtrips easier.
 

--- a/lib/Neo4j/Types/Point.pm
+++ b/lib/Neo4j/Types/Point.pm
@@ -5,35 +5,11 @@ package Neo4j::Types::Point;
 # ABSTRACT: Represents a Neo4j spatial point value
 
 
-use Carp qw(croak);
-
-
-my %DIM = ( 4326 => 2, 4979 => 3, 7203 => 2, 9157 => 3 );
-
 sub new {
-	my ($class, $srid, @coordinates) = @_;
+	warnings::warnif deprecated => "Deprecated: Use Neo4j::Types::Generic::Point->new() instead";
 	
-	croak "Points must have SRID" unless defined $srid;
-	my $dim = $DIM{$srid};
-	croak "Unsupported SRID $srid" unless defined $dim;
-	croak "Points with SRID $srid must have $dim dimensions" if @coordinates < $dim;
-	return bless [ $srid, @coordinates[0 .. $dim - 1] ], $class;
-}
-
-
-sub X { shift->[1] }
-sub Y { shift->[2] }
-sub Z { shift->[3] }
-
-sub longitude { shift->[1] }
-sub latitude  { shift->[2] }
-sub height    { shift->[3] }
-
-sub srid { shift->[0] }
-
-sub coordinates {
-	my @coordinates = @{$_[0]}[ 1 .. $#{$_[0]} ];
-	return @coordinates;
+	require Neo4j::Types::Generic::Point;
+	&Neo4j::Types::Generic::Point::new;
 }
 
 

--- a/lib/Neo4j/Types/Point.pod
+++ b/lib/Neo4j/Types/Point.pod
@@ -5,13 +5,10 @@
 
 =head1 SYNOPSIS
 
- $longitude  = $point->X;
- $latitude   = $point->Y;
- $height     = $point->Z;
  $neo4j_srid = $point->srid;
  
- @coords = ($x, $y, $z);
- $point  = Neo4j::Types::Point->new( $neo4j_srid, @coords );
+ @coordinates = $point->coordinates;
+ ($x, $y, $z) = $point->coordinates;
 
 =head1 DESCRIPTION
 
@@ -25,7 +22,10 @@ Supported in Neo4j S<version 3.4> and above.
 
 =head1 METHODS
 
-L<Neo4j::Types::Point> implements the following methods.
+L<Neo4j::Types::Point> specifies the following methods.
+Additionally, a C<new()> method is currently available
+as a backwards compatibility alias for C<new()> in
+L<Neo4j::Types::Generic/"Point">.
 
 =head2 coordinates
 
@@ -39,33 +39,6 @@ point (C<2> for points in two-dimensional coordinate systems,
 C<3> for three-dimensional systems).
 
  $dimensions = scalar $point->coordinates;
-
-=head2 height
-
- $value = $point->height;
-
-Alias for L<C<Z()>|/"Z">.
-
-=head2 latitude
-
- $value = $point->latitude;
-
-Alias for L<C<Y()>|/"Y">.
-
-=head2 longitude
-
- $value = $point->longitude;
-
-Alias for L<C<X()>|/"X">.
-
-=head2 new
-
- $point = Neo4j::Types::Point->new($neo4j_srid, @coordinates);
-
-Creates a new Point instance with the specified value.
-
-This method will fail if the SRID provided is not supported by Neo4j
-or if it requires a greater number of coordinates than provided.
 
 =head2 srid
 
@@ -152,40 +125,13 @@ not to mix different geodetic datums in the same database without
 considering the interoperability issues that this may cause, again
 particularly if more than a single client uses the Neo4j database.
 
-=head2 X
-
- $value = $point->X;
-
-Retrieve the point's first ordinate, also known as the abscissa.
-Commonly used for the horizontal axis in an Euclidean plane or for
-the geographical longitude.
-
-=head2 Y
-
- $value = $point->Y;
-
-Retrieve the point's second ordinate. Commonly used for the vertical
-axis in an Euclidean plane or for the geographical latitude.
-
-=head2 Z
-
- $value = $point->Z;
-
-Retrieve the point's third ordinate. Commonly used for height.
-
-For points in coordinate systems that have no more than two
-dimensions, this method returns an undefined value.
-
-=head1 BUGS
-
-There are currently no methods named C<x()>, C<y()>, or C<z()>.
-This is to avoid confusion with Perl's C<y///> operator.
-
 =head1 SEE ALSO
 
 =over
 
-=item * L<Neo4j::Types::ImplementorNotes/"Point">
+=item * L<Neo4j::Types::Generic/"Point">
+
+=item * L<Neo4j::Types::ImplementorNotes/"SPATIAL TYPES">
 
 =item * L<Neo4j::Driver::Type::Point>
 

--- a/t/generic-point.t
+++ b/t/generic-point.t
@@ -6,7 +6,7 @@ use lib qw(lib);
 use Test::More 0.88;
 use Test::Exception;
 use Test::Warnings;
-use Neo4j::Types::Point;
+use Neo4j::Types::Generic::Point;
 
 plan tests => 9+3+3 + 9+3+3+3 + 6+6+6+6+1 + 1;
 
@@ -14,7 +14,7 @@ plan tests => 9+3+3 + 9+3+3+3 + 6+6+6+6+1 + 1;
 
 my (@c, $p);
 
-sub new_point { bless shift, 'Neo4j::Types::Point' }
+sub new_point { bless shift, 'Neo4j::Types::Generic::Point' }
 
 
 
@@ -77,49 +77,49 @@ is scalar ($p->coordinates), 2, 'scalar context string coords';
 
 
 @c = ( 42 );
-throws_ok { Neo4j::Types::Point->new( 4326, @c ) } qr/\bdimensions\b/i, 'new 4326 X fails';
-throws_ok { Neo4j::Types::Point->new( 4979, @c ) } qr/\bdimensions\b/i, 'new 4979 X fails';
-throws_ok { Neo4j::Types::Point->new( 7203, @c ) } qr/\bdimensions\b/i, 'new 7203 X fails';
-throws_ok { Neo4j::Types::Point->new( 9157, @c ) } qr/\bdimensions\b/i, 'new 9157 X fails';
-throws_ok { Neo4j::Types::Point->new( 12345, @c ) } qr/\bUnsupported\b/i, 'new 12345 X fails';
-throws_ok { Neo4j::Types::Point->new( undef, @c ) } qr/\bSRID\b/i, 'new undef X fails';
+throws_ok { Neo4j::Types::Generic::Point->new( 4326, @c ) } qr/\bdimensions\b/i, 'new 4326 X fails';
+throws_ok { Neo4j::Types::Generic::Point->new( 4979, @c ) } qr/\bdimensions\b/i, 'new 4979 X fails';
+throws_ok { Neo4j::Types::Generic::Point->new( 7203, @c ) } qr/\bdimensions\b/i, 'new 7203 X fails';
+throws_ok { Neo4j::Types::Generic::Point->new( 9157, @c ) } qr/\bdimensions\b/i, 'new 9157 X fails';
+throws_ok { Neo4j::Types::Generic::Point->new( 12345, @c ) } qr/\bUnsupported\b/i, 'new 12345 X fails';
+throws_ok { Neo4j::Types::Generic::Point->new( undef, @c ) } qr/\bSRID\b/i, 'new undef X fails';
 
 @c = ( 2.294, 48.858 );
-$p = Neo4j::Types::Point->new( 4326, @c );
+$p = Neo4j::Types::Generic::Point->new( 4326, @c );
 is_deeply $p, new_point([ 4326, @c[0..1] ]), 'new 4326';
-throws_ok { Neo4j::Types::Point->new( 4979, @c ) } qr/\bdimensions\b/i, 'new 4979 XY fails';
-$p = Neo4j::Types::Point->new( 7203, @c );
+throws_ok { Neo4j::Types::Generic::Point->new( 4979, @c ) } qr/\bdimensions\b/i, 'new 4979 XY fails';
+$p = Neo4j::Types::Generic::Point->new( 7203, @c );
 is_deeply $p, new_point([ 7203, @c[0..1] ]), 'new 7203';
-throws_ok { Neo4j::Types::Point->new( 9157, @c ) } qr/\bdimensions\b/i, 'new 9157 XY fails';
-throws_ok { Neo4j::Types::Point->new( 12345, @c ) } qr/\bUnsupported\b/i, 'new 12345 XY fails';
-throws_ok { Neo4j::Types::Point->new( undef, @c ) } qr/\bSRID\b/i, 'new undef XY fails';
+throws_ok { Neo4j::Types::Generic::Point->new( 9157, @c ) } qr/\bdimensions\b/i, 'new 9157 XY fails';
+throws_ok { Neo4j::Types::Generic::Point->new( 12345, @c ) } qr/\bUnsupported\b/i, 'new 12345 XY fails';
+throws_ok { Neo4j::Types::Generic::Point->new( undef, @c ) } qr/\bSRID\b/i, 'new undef XY fails';
 
 @c = ( 2.294, 48.858, 396 );
-$p = Neo4j::Types::Point->new( 4326, @c );
+$p = Neo4j::Types::Generic::Point->new( 4326, @c );
 is_deeply $p, new_point([ 4326, @c[0..1] ]), 'new 4326 Z ignored';
-$p = Neo4j::Types::Point->new( 4979, @c );
+$p = Neo4j::Types::Generic::Point->new( 4979, @c );
 is_deeply $p, new_point([ 4979, @c ]), 'new 4979';
-$p = Neo4j::Types::Point->new( 7203, @c );
+$p = Neo4j::Types::Generic::Point->new( 7203, @c );
 is_deeply $p, new_point([ 7203, @c[0..1] ]), 'new 7203 Z ignored';
-$p = Neo4j::Types::Point->new( 9157, @c );
+$p = Neo4j::Types::Generic::Point->new( 9157, @c );
 is_deeply $p, new_point([ 9157, @c ]), 'new 9157';
-throws_ok { Neo4j::Types::Point->new( 12345, @c ) } qr/\bUnsupported\b/i, 'new 12345 XYZ fails';
-throws_ok { Neo4j::Types::Point->new( undef, @c ) } qr/\bSRID\b/i, 'new undef XYZ fails';
+throws_ok { Neo4j::Types::Generic::Point->new( 12345, @c ) } qr/\bUnsupported\b/i, 'new 12345 XYZ fails';
+throws_ok { Neo4j::Types::Generic::Point->new( undef, @c ) } qr/\bSRID\b/i, 'new undef XYZ fails';
 
 @c = ( 2.294, 48.858, 396, 13 );
-$p = Neo4j::Types::Point->new( 4326, @c );
+$p = Neo4j::Types::Generic::Point->new( 4326, @c );
 is_deeply $p, new_point([ 4326, @c[0..1] ]), 'new 4326 ZM ignored';
-$p = Neo4j::Types::Point->new( 4979, @c );
+$p = Neo4j::Types::Generic::Point->new( 4979, @c );
 is_deeply $p, new_point([ 4979, @c[0..2] ]), 'new 4979 M ignored';
-$p = Neo4j::Types::Point->new( 7203, @c );
+$p = Neo4j::Types::Generic::Point->new( 7203, @c );
 is_deeply $p, new_point([ 7203, @c[0..1] ]), 'new 7203 ZM ignored';
-$p = Neo4j::Types::Point->new( 9157, @c );
+$p = Neo4j::Types::Generic::Point->new( 9157, @c );
 is_deeply $p, new_point([ 9157, @c[0..2] ]), 'new 9157 M ignored';
-throws_ok { Neo4j::Types::Point->new( 12345, @c ) } qr/\bUnsupported\b/i, 'new 12345 XYZM fails';
-throws_ok { Neo4j::Types::Point->new( undef, @c ) } qr/\bSRID\b/i, 'new undef XYZM fails';
+throws_ok { Neo4j::Types::Generic::Point->new( 12345, @c ) } qr/\bUnsupported\b/i, 'new 12345 XYZM fails';
+throws_ok { Neo4j::Types::Generic::Point->new( undef, @c ) } qr/\bSRID\b/i, 'new undef XYZM fails';
 
 @c = ( undef, 45 );
-$p = Neo4j::Types::Point->new( 4326, @c );
+$p = Neo4j::Types::Generic::Point->new( 4326, @c );
 is_deeply $p, new_point([ 4326, @c[0..1] ]), 'new 4326 undef coord';
 
 


### PR DESCRIPTION
If modules for temporal types end up in the Neo4j::Types::Generic namespace, then the spatial point type should be moved there as well for consistency.

This change is potentially backwards incompatible. However, I believe there are currently no users of Neo4j::Types::Point other than possibly an unreleased branch of Neo4j::Bolt, which we can control. Any remaining risk can be minimised by keeping `Neo4j::Types::Point->new()` as an alias for `Neo4j::Types::Generic::Point->new()`, which this PR does (including a deprecation warning).